### PR TITLE
Setup version upgrade and deploy workflow

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,55 @@
+name: "Bump version"
+
+on:
+  pull_request:
+    branches:
+      - v2
+    types:
+      - closed
+
+jobs:
+  bump-version:
+    name: Bump version depending on labels
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.merged == true && (
+      contains(github.event.pull_request.labels.*.name, 'patch') ||
+      contains(github.event.pull_request.labels.*.name, 'minor') )
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Bump version
+        run: |
+          IFS=',' read -r -a label_array <<< "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+          if [[ "${label_array[*]}" =~ "minor" ]]; then
+            yarn version --minor --no-git-tag-version
+          elif [[ "${label_array[*]}" =~ "patch" ]]; then
+            yarn version --patch --no-git-tag-version
+          else
+            echo "No version bump needed"
+          fi
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Generate builds
+        run: yarn build
+
+      - name: Get the new version
+        id: get_version
+        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add package.json dist/
+          git commit -m "Bump version to ${{ steps.get_version.outputs.version }}"
+          git push origin HEAD:v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release-tags:
-    name: Generate release tags
+    name: Generate Release Tags
     runs-on: ubuntu-latest
 
     steps:
@@ -29,4 +29,38 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+  deploy:
+    name: Deploy to AWS S3
+    runs-on: ubuntu-latest
+
+    env:
+      AWS_S3_BUCKET: tarka-public-libraries
+      AWS_REGION: ap-south-1
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: v2
+
+      - name: Get the latest version
+        id: get_version
+        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
       
+      - name: Rename build files
+        run: |
+          current_version=$(echo "${{ steps.get_version.outputs.version }}")
+          mv dist/tarka-chat.es.js "dist/tarka-chat-${current_version}.es.js"
+          mv dist/tarka-chat.umd.js "dist/tarka-chat-${current_version}.umd.js"
+      
+      - name: Push the files to S3 bucket
+        uses: jakejarvis/s3-sync-action@master
+        env:
+          SOURCE_DIR: 'dist'
+          AWS_S3_BUCKET: ${{ env.AWS_S3_BUCKET }}
+          AWS_REGION: ${{ env.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,32 @@
+name: Generate tags and Deploy
+
+on: 
+  workflow_dispatch
+
+jobs:
+  release-tags:
+    name: Generate release tags
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          ref: v2
+
+      - name: Get the latest version
+        id: get_version
+        run: echo "::set-output name=version::$(node -p "require('./package.json').version")"
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: v${{ steps.get_version.outputs.version }}
+          release_name: v${{ steps.get_version.outputs.version }}
+          body: |
+            Release v${{ steps.get_version.outputs.version }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      


### PR DESCRIPTION
- Added workflow to bump version and generate latest builds depending on `minor` or `patch` label in a PR that gets merged
- Added a manually triggerable workflow to generate git tags and deploy to CDN