### PR TITLE
fix/24080: removed fixed width and height of image-container

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -125,8 +125,6 @@
 
           .image-container {
             position: relative;
-            width: 300px;
-            height: 300px;
             border: 1px solid var(--primary-primary-subtle, #f0dafb); /* Set border color as needed */
             border-radius: 15px;
             margin: 4px 0;


### PR DESCRIPTION
Made the `image-container` response according to height and width of image.
 
<img width="614" alt="Screenshot 2024-02-09 at 7 11 51 PM" src="https://github.com/tarkalabs/tarka-chat/assets/28146775/8a91ed08-c6b2-4625-b14e-04b3bf9a831a">
