### PR TITLE
Fix issue with file download not working in iframe

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -173,7 +173,7 @@ export default {
             <div class="attachment-file-name">
               ${data.name || "File"}
             </div>
-            <a href="${data.link}" class="attachment-download-btn">
+            <a href="${data.link}" class="attachment-download-btn" target="_blank">
               <img src="${downloadImg}" alt="Download Button" width="24" height="24">
             </a>
           </div>`;


### PR DESCRIPTION
- Loading file download URL in a new tab in order to avoid download failure within iframe.