### PR TITLE
Remove release md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,3 @@ where,
 
 Demo is deployed from the application code in `demo/` folder.
 Link: https://tarkalabs.github.io/tarka-chat/demo/
-
-## Old versions
-
-- v1.1 : https://d1fmfone96g0x2.cloudfront.net/tarka-chat-1.1.umd.js
-- v1.0 : https://d1fmfone96g0x2.cloudfront.net/tarka-chat-1.1.umd.js
-
-Check [release notes](RELEASE.md) for details

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,0 @@
-# v1.1
-- Fixed the issue #18 where the chat window does not render correctly in mobile view
-
-# v1.0
-Initial version


### PR DESCRIPTION
Given github has separate release section. We don't need to maintaing this in readme

![Screenshot 2024-03-15 at 6 21 35 PM](https://github.com/tarkalabs/tarka-chat/assets/363033/4b05cab0-64f4-47bf-8892-207403768738)
